### PR TITLE
Correct title in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Action to import Apple Code-signing Certificates and Keys
+# GitHub Action to download and install Provisioning Profiles
 
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](LICENSE)
 [![PRs welcome!](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
The title in the README appeared to be a copy+paste from the https://github.com/Apple-Actions/import-codesign-certs Github action.