### PR TITLE
Fix profile file extension for macOS and Mac Catalyst profiles

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -50271,7 +50271,12 @@ async function run() {
             if (!(profile.attributes.uuid && profile.attributes.profileContent)) {
                 throw new Error('Profile attributes `uuid` and `profileContent` must be defined!');
             }
-            const profileFileExtension = profile.attributes.platform === 'MAC_OS'
+            // `platform` can be undefined or `UNIVERSAL` (e.g. Mac Catalyst), so
+            // also fall back to `profileType` which covers MAC_APP_* and
+            // MAC_CATALYST_APP_*. See issue #53.
+            const isMacProfile = profile.attributes.platform === 'MAC_OS' ||
+                profile.attributes.profileType?.startsWith('MAC_');
+            const profileFileExtension = isMacProfile
                 ? 'provisionprofile'
                 : 'mobileprovision';
             const profileFilename = `${profile.attributes.uuid}.${profileFileExtension}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,10 +31,15 @@ async function run(): Promise<void> {
         )
       }
 
-      const profileFileExtension =
-        profile.attributes.platform === 'MAC_OS'
-          ? 'provisionprofile'
-          : 'mobileprovision'
+      // `platform` can be undefined or `UNIVERSAL` (e.g. Mac Catalyst), so
+      // also fall back to `profileType` which covers MAC_APP_* and
+      // MAC_CATALYST_APP_*. See issue #53.
+      const isMacProfile =
+        profile.attributes.platform === 'MAC_OS' ||
+        profile.attributes.profileType?.startsWith('MAC_')
+      const profileFileExtension = isMacProfile
+        ? 'provisionprofile'
+        : 'mobileprovision'
       const profileFilename = `${profile.attributes.uuid}.${profileFileExtension}`
       const basePath = join(
         process.env['HOME'],


### PR DESCRIPTION
The platform attribute on a profile can be undefined or `UNIVERSAL` (e.g. for Mac Catalyst), which caused macOS profiles to be saved with the `.mobileprovision` extension instead of `.provisionprofile`.

Also check the `profileType` attribute, which is set to `MAC_APP_*` for macOS profiles and `MAC_CATALYST_APP_*` for Mac Catalyst profiles.

Fixes #53