### PR TITLE
Fix non-descriptive [object Object] error messages

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -86001,6 +86001,34 @@ async function downloadActiveProvisioningProfiles(privateKey, issuerId, privateK
 }
 
 // src/main.ts
+function formatError2(error48) {
+  if (error48 instanceof Error) {
+    return error48.message;
+  }
+  if (typeof error48 === "string") {
+    return error48;
+  }
+  if (error48 && typeof error48 === "object") {
+    const apiErrors = error48.errors;
+    if (Array.isArray(apiErrors) && apiErrors.length > 0) {
+      const details = apiErrors.map((item) => {
+        if (!item || typeof item !== "object") {
+          return String(item);
+        }
+        const { status, code, title, detail } = item;
+        const parts = [code, title, detail].filter(Boolean);
+        const message2 = parts.length > 0 ? parts.join(" - ") : JSON.stringify(item);
+        return status ? `${message2} (status: ${status})` : message2;
+      }).join("; ");
+      return `App Store Connect API error: ${details}`;
+    }
+    try {
+      return `Action failed with error ${JSON.stringify(error48)}`;
+    } catch {
+    }
+  }
+  return `Action failed with error ${String(error48)}`;
+}
 async function run() {
   try {
     const bundleId = getInput("bundle-id");
@@ -86048,11 +86076,7 @@ async function run() {
     });
     setOutput("profiles", JSON.stringify(outputProfiles));
   } catch (error48) {
-    if (error48 instanceof Error) {
-      setFailed(error48.message);
-    } else {
-      setFailed(`Action failed with error ${error48}`);
-    }
+    setFailed(formatError2(error48));
   }
 }
 run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,50 @@ import {writeFileSync} from 'node:fs'
 import {join} from 'node:path'
 import {downloadActiveProvisioningProfiles} from './provisioning'
 
+// appstore-connect-sdk throwOnError throws API error bodies, not Error
+// instances — stringifying those as `${error}` yields `[object Object]` (#68).
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (error && typeof error === 'object') {
+    const apiErrors = (error as {errors?: unknown}).errors
+    if (Array.isArray(apiErrors) && apiErrors.length > 0) {
+      const details = apiErrors
+        .map(item => {
+          if (!item || typeof item !== 'object') {
+            return String(item)
+          }
+          const {status, code, title, detail} = item as {
+            status?: string
+            code?: string
+            title?: string
+            detail?: string
+          }
+          const parts = [code, title, detail].filter(Boolean)
+          const message =
+            parts.length > 0 ? parts.join(' - ') : JSON.stringify(item)
+          return status ? `${message} (status: ${status})` : message
+        })
+        .join('; ')
+      return `App Store Connect API error: ${details}`
+    }
+
+    try {
+      return `Action failed with error ${JSON.stringify(error)}`
+    } catch {
+      // Fall through for values that cannot be stringified.
+    }
+  }
+
+  return `Action failed with error ${String(error)}`
+}
+
 async function run(): Promise<void> {
   try {
     const bundleId: string = getInput('bundle-id')
@@ -62,11 +106,7 @@ async function run(): Promise<void> {
     })
     setOutput('profiles', JSON.stringify(outputProfiles))
   } catch (error) {
-    if (error instanceof Error) {
-      setFailed(error.message)
-    } else {
-      setFailed(`Action failed with error ${error}`)
-    }
+    setFailed(formatError(error))
   }
 }
 


### PR DESCRIPTION
## Summary
- Format App Store Connect API error bodies thrown by `appstore-connect-sdk` (`throwOnError`) instead of string-interpolating them as `[object Object]`
- Surface API `code`, `title`, `detail`, and `status` in the action failure message
- Rebuild `dist/index.js`

Fixes #68

## Test plan
- [ ] Trigger a failure path that returns an App Store Connect API error body (e.g. missing Program License Agreement) and confirm the log shows a readable message rather than `Action failed with error [object Object]`
- [ ] Confirm normal successful downloads still work
- [ ] Confirm ordinary `Error` throws still report `error.message`


Made with [Cursor](https://cursor.com)